### PR TITLE
ci(docs): add GitHub Actions workflow for deploying docs to GitHub Pages

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,0 +1,60 @@
+name: Deploy Docs to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: Build Docs site
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+          cache-dependency-path: docs/package.json
+
+      - name: Install dependencies
+        working-directory: docs
+        run: npm install
+
+      - name: Build VitePress
+        working-directory: docs
+        env:
+          NODE_OPTIONS: --max_old_space_size=4096
+        run: npm run docs:build
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs/.vitepress/dist
+
+  deploy:
+    name: Deploy to GitHub Pages
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Configure Pages
+        uses: actions/configure-pages@v5
+      - name: Deploy
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
Buenas @Mteheran , vi que intentaste deployar la Docs en GitHub Pages, aunque faltó configurar la etapa de Build, ya que VitePress, aunque finalmente devuelve un sitio estático, requiere una etapa de Build para esta generación.

Este PR agrega este Workflow. Lo he probado en mi fork, aunque no carga correctamente los estilos ya que no está configurado un dominio propio. Con un dominio propio configurado, funcionará correctamente: https://enzonotario.github.io/api-colombia/

Quedo atento. Saludos!