### PR TITLE
feat: per-IP rate limiting on public read endpoints

### DIFF
--- a/api.Tests/ApiRoutesTests/HolidayRateLimitTests.cs
+++ b/api.Tests/ApiRoutesTests/HolidayRateLimitTests.cs
@@ -1,0 +1,36 @@
+using System.Net;
+
+namespace api.Tests.ApiRoutesTests;
+
+// Separate test class so it gets its own CustomWebApplicationFactory instance
+// (and therefore its own in-memory rate-limiter state), keeping the burst of
+// requests below from tripping the limit for the other Holiday tests.
+public class HolidayRateLimitTests : IClassFixture<CustomWebApplicationFactory>
+{
+    private readonly HttpClient _client;
+
+    public HolidayRateLimitTests(CustomWebApplicationFactory factory)
+    {
+        _client = factory.CreateClient();
+    }
+
+    [Fact]
+    public async Task GetHolidays_ByYear_ExceedingPerIpLimit_Returns429WithRetryAfter()
+    {
+        const string url = "/api/v1/Holiday/year/2026";
+        const int permitLimit = 60; // matches SlidingWindowRateLimiterOptions.PermitLimit
+
+        // The first 60 requests (same IP, same window) must be allowed.
+        for (var i = 0; i < permitLimit; i++)
+        {
+            var allowed = await _client.GetAsync(url);
+            Assert.Equal(HttpStatusCode.OK, allowed.StatusCode);
+        }
+
+        // The 61st request in the window is rejected.
+        var rejected = await _client.GetAsync(url);
+
+        Assert.Equal(HttpStatusCode.TooManyRequests, rejected.StatusCode);
+        Assert.True(rejected.Headers.RetryAfter is not null, "Expected a Retry-After header on the 429 response.");
+    }
+}

--- a/api.Tests/ApiRoutesTests/ResourceRateLimitTests.cs
+++ b/api.Tests/ApiRoutesTests/ResourceRateLimitTests.cs
@@ -1,0 +1,53 @@
+using System.Net;
+
+namespace api.Tests.ApiRoutesTests;
+
+// Separate test class → its own CustomWebApplicationFactory instance, so this
+// burst doesn't interfere with the other resource tests. Holiday, City and
+// Department all reuse the SAME named policy (Util.PublicRateLimitPolicy,
+// partitioned by IP only), so a single client shares ONE 60/min budget across
+// the three resources.
+public class ResourceRateLimitTests : IClassFixture<CustomWebApplicationFactory>
+{
+    private const int PermitLimit = 60; // matches SlidingWindowRateLimiterOptions.PermitLimit
+
+    // The three groups that opt into the shared per-IP policy. Every URL here
+    // returns 200 with the seeded in-memory database.
+    private static readonly string[] SharedEndpoints =
+    {
+        "/api/v1/Holiday/year/2026",
+        "/api/v1/City",
+        "/api/v1/Department",
+    };
+
+    private readonly HttpClient _client;
+
+    public ResourceRateLimitTests(CustomWebApplicationFactory factory)
+    {
+        factory.ResetDatabase();
+        _client = factory.CreateClient();
+    }
+
+    [Fact]
+    public async Task Holiday_City_And_Department_ShareASinglePerIpBudget()
+    {
+        // Interleave the three resources until the shared budget is exhausted.
+        // Because they share one bucket, the total allowed across all three is 60.
+        for (var i = 0; i < PermitLimit; i++)
+        {
+            var url = SharedEndpoints[i % SharedEndpoints.Length];
+            var allowed = await _client.GetAsync(url);
+            Assert.Equal(HttpStatusCode.OK, allowed.StatusCode);
+        }
+
+        // The next request on ANY of the shared groups is rejected — proving the
+        // budget is shared, not per-resource.
+        foreach (var url in SharedEndpoints)
+        {
+            var rejected = await _client.GetAsync(url);
+            Assert.Equal(HttpStatusCode.TooManyRequests, rejected.StatusCode);
+            Assert.True(rejected.Headers.RetryAfter is not null,
+                $"Expected a Retry-After header on the 429 response for {url}.");
+        }
+    }
+}

--- a/api/Program.cs
+++ b/api/Program.cs
@@ -1,4 +1,6 @@
+using System.Globalization;
 using System.Text.Json.Serialization;
+using System.Threading.RateLimiting;
 using api;
 using api.Routes;
 using Microsoft.AspNetCore.Http.Json;
@@ -8,6 +10,7 @@ using System.Net;
 using System.IO.Compression;
 using api.Const;
 using api.Mcp;
+using Microsoft.AspNetCore.RateLimiting;
 using Microsoft.AspNetCore.ResponseCompression;
 using Microsoft.Net.Http.Headers;
 using Microsoft.OpenApi;
@@ -55,6 +58,50 @@ builder.Services.AddOutputCache(static options =>
                // Vary the cache by every query string value so ?sortBy=, ?page=,
                // ?pageSize= etc. produce distinct cache entries.
                .SetVaryByQuery("*"));
+});
+
+// Shared per-IP rate limiting for the public resource groups that opt in via
+// Util.PublicRateLimitPolicy (Holiday, City, Department, ...). Responses are
+// cached aggressively, so a client that respects the cache never approaches the
+// limit; only per-second bursts are cut. All opted-in groups share one per-IP budget.
+builder.Services.AddRateLimiter(static options =>
+{
+    options.RejectionStatusCode = StatusCodes.Status429TooManyRequests;
+
+    options.AddPolicy(Util.PublicRateLimitPolicy, static httpContext =>
+    {
+        // Partition by client IP. If the API runs behind a reverse proxy
+        // (Azure App Service, Cloudflare) consider partitioning by the first
+        // X-Forwarded-For value instead, since RemoteIpAddress may be the proxy.
+        var partitionKey = httpContext.Connection.RemoteIpAddress?.ToString() ?? "unknown";
+
+        return RateLimitPartition.GetSlidingWindowLimiter(partitionKey, static _ =>
+            new SlidingWindowRateLimiterOptions
+            {
+                PermitLimit = 60,
+                Window = TimeSpan.FromMinutes(1),
+                SegmentsPerWindow = 6,   // 10-second segments → gradual expiry
+                QueueLimit = 0,
+                AutoReplenishment = true
+            });
+    });
+
+    options.OnRejected = static async (context, ct) =>
+    {
+        // Always advertise Retry-After. The sliding window limiter doesn't attach
+        // RetryAfter metadata, so fall back to the segment length (Window /
+        // SegmentsPerWindow = 10s) — the point at which the oldest segment frees a permit.
+        var retrySeconds = context.Lease.TryGetMetadata(MetadataName.RetryAfter, out var retryAfter)
+            ? (int)retryAfter.TotalSeconds
+            : 10;
+
+        context.HttpContext.Response.Headers.RetryAfter =
+            retrySeconds.ToString(CultureInfo.InvariantCulture);
+
+        context.HttpContext.Response.StatusCode = StatusCodes.Status429TooManyRequests;
+        await context.HttpContext.Response.WriteAsJsonAsync(
+            new { message = "Rate limit exceeded. Please retry later." }, ct);
+    };
 });
 
 builder.Services.AddCors(static options =>
@@ -150,6 +197,9 @@ app.UseStaticFiles(new StaticFileOptions
     }
 });
 app.UseCors(Util.CorsPolicyName);
+// Placed before UseOutputCache so every request (including cache hits) counts
+// against the limit — bursts consume egress bandwidth even when served from cache.
+app.UseRateLimiter();
 app.UseSwagger();
 app.UseSwaggerUI();
 app.UseOutputCache();

--- a/api/Routes/CityRoutes.cs
+++ b/api/Routes/CityRoutes.cs
@@ -20,7 +20,8 @@ namespace api.Routes
             IEndpointRouteBuilder group = app
                 .MapGroup(API_CITY_ROUTE_COMPLETE)
                 .WithTags(API_CITY_TAG)
-                .CacheOutput();
+                .CacheOutput()
+                .RequireRateLimiting(Util.PublicRateLimitPolicy);
             
             group.MapGet(string.Empty, async (DBContext db,
                 [FromQuery, SwaggerParameter(Description = Swagger.sortedBy)] string? sortBy,

--- a/api/Routes/DepartmentRoutes.cs
+++ b/api/Routes/DepartmentRoutes.cs
@@ -15,7 +15,10 @@ namespace api.Routes
         {
             const string API_DEPARTMENT_ROUTE_COMPLETE = $"{Util.API_ROUTE}{Util.API_VERSION}{Util.DEPARTMENT_ROUTE}";
             const string API_DEPARTMENT_TAG = "Department";
-            IEndpointRouteBuilder group = app.MapGroup(API_DEPARTMENT_ROUTE_COMPLETE).WithTags(API_DEPARTMENT_TAG).CacheOutput();
+            IEndpointRouteBuilder group = app.MapGroup(API_DEPARTMENT_ROUTE_COMPLETE)
+                .WithTags(API_DEPARTMENT_TAG)
+                .CacheOutput()
+                .RequireRateLimiting(Util.PublicRateLimitPolicy);
 
             group.MapGet(string.Empty, async (DBContext db,
                 [FromQuery, SwaggerParameter(Description = Swagger.sortedBy)] string? sortBy,

--- a/api/Routes/HolidayRoutes.cs
+++ b/api/Routes/HolidayRoutes.cs
@@ -13,7 +13,10 @@ namespace api.Routes
         {
             const string API_HOLIDAY_ROUTE_COMPLETE = $"{Util.API_ROUTE}{Util.API_VERSION}{Util.HOLIDAY_ROUTE}";
             const string API_HOLIDAY_TAG = "Holiday";
-            IEndpointRouteBuilder group = app.MapGroup(API_HOLIDAY_ROUTE_COMPLETE).WithTags(API_HOLIDAY_TAG).CacheOutput();
+            IEndpointRouteBuilder group = app.MapGroup(API_HOLIDAY_ROUTE_COMPLETE)
+                .WithTags(API_HOLIDAY_TAG)
+                .CacheOutput()
+                .RequireRateLimiting(Util.PublicRateLimitPolicy);
 
             group.MapGet("/year/{year}", async (int year,[FromQuery] bool? includeSunday, DBContext db) =>
             { 

--- a/api/Utils/Util.cs
+++ b/api/Utils/Util.cs
@@ -5,6 +5,10 @@
         // Shared names and routes
         public const string CorsPolicyName = "corsApiColombia";
 
+        // Shared per-IP rate limiting policy. Applied to several public resource
+        // groups (Holiday, City, Department, ...); they share a single per-IP budget.
+        public const string PublicRateLimitPolicy = "publicRateLimit";
+
         public const string CITY_ROUTE = "City";
         public const string COUNTRY_ROUTE = "Country";
         public const string DEPARTMENT_ROUTE = "Department";


### PR DESCRIPTION
## Contexto
Ante la preocupación por ráfagas por segundo (y su costo de egress) contra endpoints
públicos, se añade rate limiting por IP como medida de contención. Se aplica a los
grupos Holiday, City y Department.

## Qué hace
- Política compartida por IP (`Util.PublicRateLimitPolicy`): ventana deslizante de
  60 solicitudes/minuto por IP (6 segmentos de 10 s).
- Al excederse: HTTP 429 con encabezado `Retry-After` y cuerpo JSON.
- `UseRateLimiter()` va antes de `UseOutputCache()`, así incluso las respuestas
  cacheadas cuentan contra el límite (protege egress en ráfagas).
- Los tres grupos comparten intencionalmente un único presupuesto por IP.

No requiere paquetes NuGet nuevos: el rate limiting viene integrado en .NET 10.

## Detalle de implementación
El SlidingWindowRateLimiter de .NET no adjunta metadata RetryAfter, así que
`OnRejected` usa un fallback a 10 s para siempre emitir el encabezado.

## Tests
- HolidayRateLimitTests: 60×200 → 429 con Retry-After.
- ResourceRateLimitTests: intercala Holiday + City + Department y verifica el
  presupuesto compartido (61.ª solicitud da 429).
- 246/246 tests pasan.

## Pendiente de revisión (proxy)
Si la API corre detrás de un proxy inverso, `RemoteIpAddress` puede ser la IP del
proxy → habría que particionar por X-Forwarded-For. Señalado en el código.