### PR TITLE
feat: per-IP rate limiting on public read endpoints (v1.2.0)

### DIFF
--- a/.claude/skills/finish-feature/SKILL.md
+++ b/.claude/skills/finish-feature/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: finish-feature
+description: >-
+  Run the api-colombia feature-completion checklist: add/extend tests, run
+  dotnet test, bump the version (semver), and update the CHANGELOG plus docs and
+  README when public behavior changed. Use when finishing a new feature or an
+  important change, or when the user says a change is "done" / "ready" and wants
+  it properly tested, versioned, and documented before committing.
+---
+
+# Finish Feature — closing checklist
+
+Use this after implementing a new feature or an important change in **api-colombia**, before committing. Work through the steps in order. Don't skip a step silently — if one doesn't apply, say so briefly and move on.
+
+## 0. Understand what changed
+
+- Run `git status` and `git diff` (and `git diff --staged`) to see the actual change and its scope.
+- State in one or two sentences what behavior changed and whether it is **user-facing** (new/changed endpoint, response shape, limit, header) or **internal-only** (refactor, tooling). This drives how much of steps 4–5 apply.
+
+## 1. Tests
+
+Follow the repo conventions (see `CLAUDE.md` → "When adding or changing an endpoint", step 5). Tests live in `api.Tests/`.
+
+- Add or extend tests that exercise the new behavior end-to-end. Integration tests use `CustomWebApplicationFactory` (`api.Tests/ApiRoutesTests/`).
+- Cover the happy path **and** the notable edge cases / failure modes of what you changed.
+- **Isolation gotcha:** each test class shares one `WebApplicationFactory` instance. If a test needs a lot of requests or its own app state (e.g. exhausting a rate limit), put it in its **own test class** so it gets its own factory instance and doesn't contaminate other tests. (See `ResourceRateLimitTests` / `HolidayRateLimitTests` for the pattern.)
+- Keep the API `GET`-only and read-only — never add write operations.
+
+## 2. Run the tests
+
+- From the repo root or `api.Tests/`: `dotnet test`.
+- **All tests must pass.** If anything fails, fix it (or the code) and re-run before continuing. Report the final pass count.
+
+## 3. Bump the version
+
+Edit `api/Const/Version.cs` (`VersionInfo.CurrentVersion`), which is shown in Swagger. Apply [semantic versioning](https://semver.org/):
+
+| Change | Bump | Example |
+| --- | --- | --- |
+| New endpoint/feature, backward-compatible | **minor** | 1.1.0 → 1.2.0 |
+| Bug fix, no API surface change | **patch** | 1.2.0 → 1.2.1 |
+| Breaking change to an existing endpoint/response | **major** | 1.2.0 → 2.0.0 |
+
+Internal-only refactors with no behavior change usually don't need a bump — if unsure, ask the user.
+
+## 4. Update the CHANGELOG
+
+Edit `CHANGELOG.md` (Keep a Changelog format):
+
+- Add a new `## [<version>] - YYYY-MM-DD` section above the previous one, using **today's date**.
+- Group notes under `### Added` / `### Changed` / `### Fixed` / `### Deprecated` / `### Removed` / `### Security` as appropriate.
+- Add the inline release link right after the section, matching the existing style:
+  `[<version>]: https://github.com/Mteheran/api-colombia/releases/tag/v<version>`
+- Write for API consumers: what they can now do or must know, not internal mechanics.
+
+## 5. Update documentation (only if user-facing)
+
+If the change affects public behavior, update the relevant docs. Skip for internal-only changes.
+
+- **VitePress docs** (`docs/`): most endpoint reference is generated from OpenAPI, but conceptual topics get their own page (e.g. `docs/mcp.md`, `docs/rate-limiting.md`) wired into `docs/.vitepress/config.ts` (nav + sidebar). Add or update a page when the concept isn't covered by the auto-generated reference.
+- **Swagger metadata**: endpoint summaries/descriptions live in `api/Utils/Messages.cs` under `EndpointMetadata` — update there, not inline.
+- **README.md and README_es.md**: update **both** (English + Spanish) if the change alters something documented there (feature list, usage, limits). Keep them in sync.
+- **Landing / dashboard** (`api/wwwroot/index.html`, `metrics.html`): update if the change is worth surfacing to visitors. `index.html` uses i18n — add keys to `api/wwwroot/js/translations.json` for **es/en/pt**, not hardcoded text.
+
+## 6. Wrap up
+
+- Run `dotnet build` once more to confirm 0 errors.
+- Give the user a short summary: what changed, tests result, new version, docs touched.
+- **Do not commit, push, or open a PR unless the user asks.** When they do: branch first if on `main`, stage only the relevant files (never `.DS_Store`), and end the commit message with the project's `Co-Authored-By` trailer.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning].
 
 - /
 
+## [1.2.0] - 2026-07-11
+
+### Added
+
+- **Per-IP rate limiting** on the highest-traffic public endpoints (**Holiday, City, Department**) to keep the service stable under heavy demand (2M+ requests/month). A shared sliding-window policy allows **60 requests per minute per IP**; requests over the limit receive **HTTP 429 Too Many Requests** with a `Retry-After` header.
+    - The three groups share a single per-IP budget through one named policy (`Util.PublicRateLimitPolicy`).
+    - `UseRateLimiter` runs before the output cache, so bursts are throttled even when a response could be served from cache — protecting outbound (egress) bandwidth.
+    - Consumer tip: most of this data changes rarely, so **cache responses on the client side** (or honor the API's 7-day cache) instead of requesting them on every call.
+    - Integration tests cover both the Holiday limit and the shared budget across the three resources.
+
+[1.2.0]: https://github.com/Mteheran/api-colombia/releases/tag/v1.2.0
+
 ## [1.1.0] - 2026-07-09
 
 ### Added

--- a/api/Const/Version.cs
+++ b/api/Const/Version.cs
@@ -2,5 +2,5 @@ namespace api.Const;
 
 public static class VersionInfo
 {
-    public const string CurrentVersion = "1.1.0";
+    public const string CurrentVersion = "1.2.0";
 }

--- a/api/wwwroot/index.html
+++ b/api/wwwroot/index.html
@@ -254,6 +254,17 @@
           <button data-i18n-key="readDocs" class="botonDocumentacion" type="button">Lee la
             documentación</button>
 
+          <p class="rate-limit-note"
+            style="margin-top:16px;padding:12px 16px;border-left:4px solid #f9c74f;background:rgba(249,199,79,.10);border-radius:8px;font-size:14px;line-height:1.5;">
+            <span data-i18n-key="rateLimitNote">
+              ⚡ Para mantener el servicio estable ante la alta demanda, algunos endpoints tienen un
+              límite de 60 solicitudes por minuto por IP. Como estos datos cambian poco, te
+              recomendamos guardarlos en caché en tu aplicación.
+            </span>
+            <a href="https://docs.api-colombia.com/rate-limiting" target="_blank" rel="noopener"
+              data-i18n-key="rateLimitLink">Más información</a>
+          </p>
+
           <div class="cards">
             <article class="caja uno">
               <img src="./assets/crown-decorative.svg"

--- a/api/wwwroot/js/translations.json
+++ b/api/wwwroot/js/translations.json
@@ -1,7 +1,7 @@
 {
   "es": {
     "title": "Explora Colombia con API-Colombia",
-    "explore": "Explora", 
+    "explore": "Explora",
     "with": "con",
     "subtitle": "Un proyecto Open-source que ofrece acceso a datos sobre su diversidad, todo a tu alcance.",
     "menu": "Menú",
@@ -51,11 +51,13 @@
     "sponsorsDescription1": "Gracias al apoyo de nuestros patrocinadores, API-Colombia se mantiene activa y gratuita, con más de",
     "sponsorsDescription2": "solicitudes mensuales.",
     "sponsorsDescription3": "Creemos en la colaboración abierta. Si deseas apoyar este proyecto, puedes convertirte en patrocinador también.",
-    "askAI": "Pregunta a la IA"
+    "askAI": "Pregunta a la IA",
+    "rateLimitNote": "⚡ Para mantener el servicio estable ante la alta demanda, algunos endpoints tienen un límite de 60 solicitudes por minuto por IP. Como estos datos cambian poco, te recomendamos guardarlos en caché en tu aplicación.",
+    "rateLimitLink": "Más información"
   },
   "en": {
     "title": "Explore Colombia with API-Colombia",
-    "explore": "Explore", 
+    "explore": "Explore",
     "with": "with",
     "subtitle": "An open-source project that provides access to data about its diversity, all at your fingertips.",
     "menu": "Menu",
@@ -105,11 +107,13 @@
     "sponsorsDescription1": "Thanks to the support of our sponsors, API-Colombia remains active and free, with over",
     "sponsorsDescription2": "monthly requests.",
     "sponsorsDescription3": "We believe in open collaboration. If you want to support this project, you can become a sponsor too.",
-    "askAI": "Ask AI"
+    "askAI": "Ask AI",
+    "rateLimitNote": "⚡ To keep the service stable under high demand, some endpoints are limited to 60 requests per minute per IP. Since this data rarely changes, we recommend caching it in your application.",
+    "rateLimitLink": "Learn more"
   },
   "pt": {
     "title": "Explore a Colômbia com API-Colombia",
-    "explore": "Explore", 
+    "explore": "Explore",
     "with": "com",
     "subtitle": "Um projeto open-source que oferece acesso a dados sobre sua diversidade, tudo ao seu alcance.",
     "menu": "Menu",
@@ -159,6 +163,8 @@
     "sponsorsDescription1": "Graças ao apoio de nossos patrocinadores, a API-Colombia permanece ativa e gratuita, com mais de",
     "sponsorsDescription2": "solicitações mensais.",
     "sponsorsDescription3": "Acreditamos na colaboração aberta. Se você deseja apoiar este projeto, pode se tornar um patrocinador também.",
-    "askAI": "Pergunte à IA"
+    "askAI": "Pergunte à IA",
+    "rateLimitNote": "⚡ Para manter o serviço estável sob alta demanda, alguns endpoints têm um limite de 60 solicitações por minuto por IP. Como esses dados mudam pouco, recomendamos armazená-los em cache no seu aplicativo.",
+    "rateLimitLink": "Saiba mais"
   }
 }

--- a/api/wwwroot/metrics.html
+++ b/api/wwwroot/metrics.html
@@ -73,6 +73,11 @@
     .bar-value { fill: var(--text); font-size: 10px; font-family: var(--mono); }
 
     .empty { color: var(--muted); font-size: 13px; padding: 8px 2px; }
+    .note { margin-bottom: 20px; padding: 12px 16px; border-radius: 10px;
+      background: rgba(88,166,255,.10); border: 1px solid var(--blue); color: var(--text); font-size: 13px; }
+    .note strong { color: var(--blue); }
+    .note code { font-family: var(--mono); background: rgba(255,255,255,.06); padding: 1px 5px; border-radius: 5px; }
+    .note a { color: var(--accent2); }
     #banner { display: none; margin: 0 24px 16px; padding: 10px 14px; border-radius: 8px;
       background: rgba(242,109,109,.12); border: 1px solid var(--danger); color: var(--danger); font-size: 13px; }
     footer { text-align: center; color: var(--muted); font-size: 12px; padding: 20px; }
@@ -96,6 +101,14 @@
   <div id="banner"></div>
 
   <main>
+    <div class="note">
+      <strong>⚡ Rate limiting:</strong> to keep the service stable under high demand, the busiest
+      endpoints (<code>Holiday</code>, <code>City</code>, <code>Department</code>) are limited to
+      <strong>60 requests per minute per IP</strong>. Exceeding it returns <code>429</code> with a
+      <code>Retry-After</code> header. Since this data changes rarely, please cache responses on your side.
+      <a href="https://docs.api-colombia.com/rate-limiting" target="_blank" rel="noopener">Learn more →</a>
+    </div>
+
     <section class="stats" id="stats"></section>
 
     <div class="grid">

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -14,6 +14,7 @@ export default defineConfig({
   themeConfig: {
     nav: [
       { text: 'API Reference', link: '/' },
+      { text: 'Rate Limiting', link: '/rate-limiting' },
       { text: 'MCP Server', link: '/mcp' },
       { text: 'GitHub', link: 'https://github.com/Mteheran/api-colombia' }
     ],
@@ -21,6 +22,10 @@ export default defineConfig({
       {
         text: 'Introduction',
         link: '/',
+      },
+      {
+        text: 'Rate Limiting',
+        link: '/rate-limiting',
       },
       {
         text: 'MCP Server',

--- a/docs/rate-limiting.md
+++ b/docs/rate-limiting.md
@@ -1,0 +1,50 @@
+# Rate limiting
+
+To keep API Colombia fast and stable under heavy demand (**2M+ requests per month**), the busiest public endpoints apply a lightweight **per-IP rate limit**. The API stays open, free, and requires no authentication — the limit only trims abusive bursts.
+
+## What is limited
+
+A shared limit currently applies to the highest-traffic resource groups:
+
+- **Holiday** — `/api/v1/Holiday/*`
+- **City** — `/api/v1/City/*`
+- **Department** — `/api/v1/Department/*`
+
+All other endpoints are unaffected for now.
+
+## The limit
+
+| Property | Value |
+| --- | --- |
+| Scope | Per client IP address |
+| Allowance | **60 requests per minute** |
+| Algorithm | Sliding window (1-minute window, 10-second segments) |
+| Shared budget | Holiday + City + Department count against the **same** per-IP budget |
+
+Because the three groups share one budget, a client that mixes calls across them (e.g. 30 to City and 30 to Department in the same minute) consumes the full 60-request allowance.
+
+## When you exceed it
+
+Requests over the limit receive:
+
+- **`429 Too Many Requests`**
+- A **`Retry-After`** header (in seconds) telling you how long to wait
+- A small JSON body:
+
+```json
+{ "message": "Rate limit exceeded. Please retry later." }
+```
+
+## Recommended: cache on your side
+
+Most of this data changes rarely — holidays are deterministic, and cities/departments change infrequently. **You should not request it on every call.**
+
+- Store the responses in a **cache or in-memory store** in your application and refresh them occasionally (e.g. once a day).
+- The API already sends aggressive cache headers (responses are cacheable for up to **7 days**), so an HTTP cache or CDN in front of your app will also keep you well under the limit.
+- Respect the `Retry-After` header with an exponential backoff if you ever hit a `429`.
+
+Following these practices means a normal integration will effectively never reach the rate limit.
+
+## Behind a proxy?
+
+The limit is keyed on the client IP as seen by the API. Normal clients need to do nothing. If you operate a proxy or gateway in front of many users, be aware that all of them may appear under a single IP.


### PR DESCRIPTION
## Contexto

Ante la alta demanda de la API (2M+ solicitudes/mes) y ráfagas por segundo contra
endpoints públicos —con su costo de egress— se añade **rate limiting por IP** como
medida de contención. La API sigue siendo abierta, gratuita y sin autenticación;
el límite solo recorta ráfagas abusivas.

## Qué hace

- **Política compartida por IP** (`Util.PublicRateLimitPolicy`): ventana deslizante
  de **60 solicitudes/minuto por IP** aplicada a los grupos con más tráfico:
  **Holiday, City y Department**.
- Al excederse: **HTTP 429 Too Many Requests** con encabezado **`Retry-After`** y
  cuerpo JSON.
- `UseRateLimiter()` se ejecuta **antes** de `UseOutputCache()`, así incluso las
  respuestas servidas desde caché cuentan contra el límite (protege el ancho de
  banda de egress).
- Los tres grupos **comparten intencionalmente un único presupuesto por IP**.

No requiere paquetes NuGet nuevos: el rate limiting viene integrado en .NET 10.

## Detalle de implementación

- El `SlidingWindowRateLimiter` de .NET no adjunta metadata `RetryAfter`, así que
  `OnRejected` usa un fallback (10 s = ventana/segmentos) para **siempre** emitir el
  encabezado.

## Tests

- `HolidayRateLimitTests`: 60×200 → 429 con `Retry-After`.
- `ResourceRateLimitTests`: intercala Holiday + City + Department y verifica el
  **presupuesto compartido** (la 61.ª solicitud en cualquier resource da 429).
- Cada test vive en su propia clase → factory aislado, sin contaminar los demás.
- **246/246 tests pasan.** Verificado además end-to-end contra la API en ejecución.

## Documentación y versión

- Versión **1.1.0 → 1.2.0** (`api/Const/Version.cs`, visible en Swagger).
- **CHANGELOG**: nueva entrada `[1.2.0]`.
- Nueva página de docs **`/rate-limiting`** (VitePress) + entradas en nav y sidebar.
- Nota informativa en la **landing** (`index.html`, i18n ES/EN/PT) y banner en el
  **dashboard de métricas** (`metrics.html`).

## Tooling

- Nuevo skill de proyecto **`/finish-feature`** (`.claude/skills/`) que formaliza el
  checklist de cierre: tests → versión → changelog → docs.

## Consideración pendiente (proxy)

Si la API corre detrás de un proxy inverso (Azure App Service / Cloudflare),
`RemoteIpAddress` puede ser la IP del proxy → habría que particionar por el primer
valor de `X-Forwarded-For`. Queda señalado en un comentario en el código.

🤖 Generated with [Claude Code](https://claude.com/claude-code)