### PR TITLE
docs: add official website link to READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@
 ## Introduction
 API Colombia is a public RESTful API that enables users to access a wide range of public information about the country of Colombia.
 
+🌐 **Official website: [api-colombia.com](https://api-colombia.com/)**
+
 📚 **[VitePress](https://docs.api-colombia.com/)** | **[Swagger](https://api-colombia.com/swagger/index.html)**  | 🤖 **[Ask AI about API-Colombia](https://www.deepgithub.com/Mteheran/api-colombia)** 
 
 

--- a/README_es.md
+++ b/README_es.md
@@ -3,6 +3,8 @@
 ## Introducción
 API Colombia es una API pública RESTful que permite a los usuarios obtener una variedad de información pública sobre Colombia.
 
+🌐 **Sitio web oficial: [api-colombia.com](https://api-colombia.com/)**
+
 ## Tutoriales en Video
 
 Aprende a usar API-Colombia con videos detallados que te explican la API paso a paso:


### PR DESCRIPTION
## What changed

Added a prominent **Official website** reference to [api-colombia.com](https://api-colombia.com/) in the introduction of both READMEs:

- `README.md` (English) — "🌐 Official website: api-colombia.com"
- `README_es.md` (Spanish) — "🌐 Sitio web oficial: api-colombia.com"

## Why

To clearly identify api-colombia.com as the official website of the project from the top of the documentation.

## Notes for reviewers

- Only the two project READMEs were changed. `api/wwwroot/README.md` was intentionally left untouched since it belongs to a third-party HTML documentation template unrelated to the project.

🤖 Generated with [Claude Code](https://claude.com/claude-code)